### PR TITLE
add black git hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.8.0
+    hooks:
+      - id: black
+        args: [--safe, --quiet]
+
+  # - repo: https://github.com/pylint-dev/pylint
+  #   rev: v3.2.7
+  #   hooks:
+  #     - id: pylint
+  #       args: [--disable=C0301, --jobs=4, --output-format=colorized, "--msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.black]
+line-length = 88
+skip-magic-trailing-comma = true
+target-version = ['py310']
+include = '\.pyi?$'
+exclude = '''
+/(
+  \.toml
+  |\.sh
+  |\.git
+  |\.ini
+  |Dockerfile
+)/
+'''

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+cryptoconditions==0.8.1
+pysha3==1.0.2
+python-rapidjson==1.8
+requests==2.28.1
+black==22.8.0
+pre-commit==3.8.0


### PR DESCRIPTION
Fixes #19 

### Description

Aim: Add a pre-commit hook which checks and applies black formatting when git commit is done.

### Steps to perform to set up the git hooks in your local repository:
```
pip install -r requirements-dev.txt
pre-commit install
```

We can include these instructions in README.

Reference for `.pre-commit-config.yaml` : https://github.com/arrow-py/arrow/blob/master/.pre-commit-config.yaml



